### PR TITLE
Add common actions for versioning and ECR deploy

### DIFF
--- a/.github/actions/docker-build-and-deploy-to-ecr/action.yml
+++ b/.github/actions/docker-build-and-deploy-to-ecr/action.yml
@@ -1,0 +1,75 @@
+# Action to build then push a given Docker image to ECR, creating the
+# repository name in ECR first if it does not exist.
+name: 'Docker build and deploy to ECR'
+description: 'Push Docker image to ECR, creating repository if necessary'
+inputs:
+  dockerfile-dir:
+    description: 'The directory containing the Docker file to build; e.g. "build-dir"'
+    required: true
+  image-name:
+    description: 'The name of the Docker image to push; e.g. "some-image"'
+    required: true
+  image-version:
+    description: 'The version of the Docker image to push; e.g. "1.2.3"'
+    required: true
+  ecr-registry-path:
+    description: 'The path part of the repository name; i.e. the "alpha" in "alpha/docker-image-name"'
+    required: true
+  aws-region:
+    description: 'The AWS region to deploy to'
+    required: true
+  role-to-assume:
+    description: 'The AWS role for authentication'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: AWS credential setup
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        # triggering-actor could differ for re-runs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+        role-session-name: role-session-name-${{ github.actor }}-${{ github.triggering_actor }}
+    - name: AWS ECR login
+      id: aws-ecr-login
+      uses: aws-actions/amazon-ecr-login@v1
+    - name: Docker build and tag
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.aws-ecr-login.outputs.registry }}
+        REGISTRY_PATH: ${{ inputs.ecr-registry-path }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_VERSION: ${{ inputs.image-version }}
+        ECR_REPOSITORY_NAME: ${{ inputs.ecr-registry-path }}/${{ inputs.image-name }}
+      run: |
+        docker images
+        docker build \
+          --tag "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_VERSION}" \
+          "${{ inputs.dockerfile-dir }}"
+        docker images
+    - name: 'AWS ECR docker push'
+      shell: bash
+      env:
+        REGISTRY: ${{ steps.aws-ecr-login.outputs.registry }}
+        REGISTRY_PATH: ${{ inputs.ecr-registry-path }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        IMAGE_TAG: ${{ inputs.image-version }}
+        ECR_REPOSITORY_NAME: ${{ inputs.ecr-registry-path }}/${{ inputs.image-name }}
+      run: |
+        # Create ECR repository if it doesn't exist
+        if [[ $(aws ecr describe-repositories \
+          --region "${{ inputs.aws-region }}" \
+          --repository-names "${ECR_REPOSITORY_NAME}" \
+        ) ]]; then
+          printf 'Repository "%s" already exists' "${ECR_REPOSITORY_NAME}"
+        else
+          printf 'Creating repository "%s"' "${ECR_REPOSITORY_NAME}"
+          aws ecr create-repository \
+            --region "${{ inputs.aws-region }}" \
+            --repository-name "${ECR_REPOSITORY_NAME}" \
+            --image-scanning-configuration \
+            scanOnPush=true
+        fi
+
+        docker push "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}:${IMAGE_TAG}"

--- a/.github/actions/get-next-version/README.md
+++ b/.github/actions/get-next-version/README.md
@@ -1,0 +1,15 @@
+# get-next-version
+
+GitHub action and supporting script to return the next version number by
+incrementing the patch number of the latest Git tag. An optional suffix can be
+appended (e.g. "beta" for "1.2.3-beta").
+
+# Testing
+
+```bash
+cd .github/actions/get-next-version
+python3 -m venv .venv
+. ./.venv/bin/activate
+pip install --requirement requirements.txt
+python3 -m unittest discover . -p 'test_*.py'
+```

--- a/.github/actions/get-next-version/action.yml
+++ b/.github/actions/get-next-version/action.yml
@@ -1,0 +1,45 @@
+# Action to get the next version number for a specified repository. An
+# optional version suffix can be supplied (e.g. "beta" for "1.2.3-beta")
+name: 'Get next version'
+description: 'Get the next version number after the latest git tag'
+inputs:
+  repo-name:
+    description: 'The name of the repository to get the latest version for'
+    required: true
+  version-suffix:
+    description: 'Optional version suffix (e.g. "beta" for "1.2.3-beta")'
+    required: false
+outputs:
+  next-version:
+    description: The next version for the repository
+    value: ${{ steps.next-tag.outputs.next-version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Setup
+      shell: bash
+      run: |
+        printf 'github.action_path=%s\n' "${{ github.action_path }}"
+        printf '$inputs.repo-name=%s\n' "${{ inputs.repo-name }}"
+        # The following cd command does not persist across steps
+        cd '${{ github.action_path }}'
+        pip install --requirement requirements.txt
+    - name: 'Set PYTHONPATH to "${{ github.action_path }}"'
+      shell: bash
+      run: |
+        echo "PYTHONPATH=${{ github.action_path }}" >> $GITHUB_ENV
+    - name: 'Get next version for repository "${{ inputs.repo-name }}"'
+      id: next-tag
+      shell: python
+      run: |
+        import os
+        from get_next_version import get_next_version
+        
+        next_version = get_next_version(
+            repo_name='${{ inputs.repo-name }}',
+            version_suffix='${{ inputs.version-suffix }}'
+        )
+        
+        # Save step output values in GitHub's step output file
+        with open(os.getenv('GITHUB_OUTPUT'), 'a') as f:
+            f.write(f'next-version={next_version}')

--- a/.github/actions/get-next-version/get_next_version.py
+++ b/.github/actions/get-next-version/get_next_version.py
@@ -1,0 +1,47 @@
+import requests
+import semver
+
+
+def get_next_version(
+        repo_name: str,
+        version_suffix: str=None,
+        github_api_url: str='https://api.github.com',
+        github_repo_prefix: str='/repos/nationalarchives/',
+        github_repo_suffix: str='/tags',
+        version_if_no_tags: str='0.0.1'
+):
+    """
+    Get the latest git tag in `repo_name` and return the next patch version,
+    or `version_if_no_tags` if no existing tags found. An optional
+    `version_suffix` can be appended (e.g. to return "1.2.3-alpha" or
+    "1.2.3-ceebe6c" instead of just "1.2.3").
+    
+    Examples:
+    * If the latest tag in `repo_name` is "2.3.3", "2.3.4" would be returned
+    * If the latest tag in `repo_name` is "2.3.3", and "ceebe6c" is passed as
+      the `version_suffix` argument, "2.3.4-ceebe6c" would be returned
+    """
+    tag_url = f'{github_api_url}{github_repo_prefix}{repo_name}{github_repo_suffix}'
+    response = requests.get(tag_url)
+    response.raise_for_status()  # raise error if response not OK
+    response_json = response.json()
+
+    # Check have expected list of items
+    if not isinstance(response_json, list):
+        raise ValueError('Tag list is not a JSON list type')
+
+    # Set a default value; overwritten unless no existing tags found
+    next_version = semver.VersionInfo.parse(version_if_no_tags)
+
+    # Check for existing tags
+    if len(response_json) > 0:
+        latest_tag_record = response_json[0]
+        KEY_NAME = 'name'
+        if KEY_NAME not in latest_tag_record:
+            raise ValueError(f'Latest record does not have key "{KEY_NAME}"')
+
+        latest_tag_version = latest_tag_record[KEY_NAME]
+        next_version = semver.VersionInfo.parse(latest_tag_version).bump_patch()
+
+    # Return the new version, with optional version_suffix
+    return str(next_version.replace(prerelease=version_suffix))

--- a/.github/actions/get-next-version/requirements.txt
+++ b/.github/actions/get-next-version/requirements.txt
@@ -1,0 +1,2 @@
+requests
+semver

--- a/.github/actions/get-next-version/test_get_next_version.py
+++ b/.github/actions/get-next-version/test_get_next_version.py
@@ -1,7 +1,7 @@
 import unittest
 from get_next_version import get_next_version
 
-TEST_REPO_NAME = 'tre-blueprint-test-repository'
+TEST_REPO_NAME = 'tre-github-actions'
 
 class TestGetNextVersion(unittest.TestCase):
     """

--- a/.github/actions/get-next-version/test_get_next_version.py
+++ b/.github/actions/get-next-version/test_get_next_version.py
@@ -1,0 +1,41 @@
+import unittest
+from get_next_version import get_next_version
+
+TEST_REPO_NAME = 'tre-blueprint-test-repository'
+
+class TestGetNextVersion(unittest.TestCase):
+    """
+    Test the get_next_version function.
+    """
+    def test_basic_run(self):
+        """
+        Test output as expected.
+        """
+        result = get_next_version(repo_name=TEST_REPO_NAME)
+        values = result.split('.')
+        major = int(values[0])
+        minor = int(values[1])
+        patch = int(values[2])
+        self.assertTrue(isinstance(major, int))
+        self.assertTrue(isinstance(minor, int))
+        self.assertTrue(isinstance(patch, int))
+
+    def test_suffix(self):
+        """
+        Test suffix added as expected.
+        """
+        test_version_suffix = 'a-test-version-suffix'
+        result = get_next_version(
+            repo_name=TEST_REPO_NAME,
+            version_suffix=test_version_suffix
+        )
+
+        parts = result.split('-', maxsplit=1)
+        self.assertTrue(parts[1] == test_version_suffix)
+        values = parts[0].split('.')
+        major = int(values[0])
+        minor = int(values[1])
+        patch = int(values[2])
+        self.assertTrue(isinstance(major, int))
+        self.assertTrue(isinstance(minor, int))
+        self.assertTrue(isinstance(patch, int))

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/
+.venv*/
+venv*/
+tmp/


### PR DESCRIPTION
Added the following reusable actions:
* .github/actions/docker-build-and-deploy-to-ecr
* .github/actions/get-next-version