### PR TITLE
Feature/dte 543/GitHub action env names

### DIFF
--- a/.github/workflows/tf-plan-approve-apply.yml
+++ b/.github/workflows/tf-plan-approve-apply.yml
@@ -5,6 +5,9 @@ on:
       environment:
         type: string
         required: true
+      environment-for-approval:
+        type: string
+        required: true
       tf_dir:
         type: string
         required: true             
@@ -17,7 +20,6 @@ on:
         required: true
       SLACK_TOKEN:
         required: true
-
 env:
   SLACK_CHANNEL: a # da-tre-automated-messages
   SLACK_WEBHOOK: ${{ secrets.SLACK_TOKEN }}
@@ -78,7 +80,7 @@ jobs:
     needs: 
       - plan
     runs-on: ubuntu-latest
-    environment: poc-manual-step
+    environment: ${{ inputs.environment-for-approval }}
     steps:
       - name: Manual Approve Info
         run: |

--- a/.github/workflows/tf-plan-approve-apply.yml
+++ b/.github/workflows/tf-plan-approve-apply.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: nationalarchives/tre-github-actions
-      - name: Copy /Scripts
+      - name: Copy /scripts
         run: |
           pwd
           ls -la ../
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive        
-      - name: Move /Scrpits to Working Directory
+      - name: Move /scripts to Working Directory
         run: |
           pwd
           ls -la ../
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: nationalarchives/tre-github-actions
-      - name: Copy /Scripts
+      - name: Copy /scripts
         run: |
           pwd
           ls -la ../
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive           
-      - name: Move /Scrpits to Working Directory
+      - name: Move /scripts to Working Directory
         run: |
           pwd
           ls -la ../

--- a/.github/workflows/tf-plan-approve-apply.yml
+++ b/.github/workflows/tf-plan-approve-apply.yml
@@ -10,7 +10,7 @@ on:
         required: true
       tf_dir:
         type: string
-        required: true             
+        required: true
     secrets:
       ROLE_ARN:
         required: true
@@ -51,11 +51,11 @@ jobs:
         run: |
           pwd
           ls -la ../
-          cp -r scripts ../          
+          cp -r scripts ../
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          submodules: recursive        
+          submodules: recursive
       - name: Move /scripts to Working Directory
         run: |
           pwd
@@ -73,11 +73,11 @@ jobs:
         run: |
           ./scripts/plan.sh
       - name: Send to Slack
-        run: | 
+        run: |
           pwd
           python3 scripts/log.py
   approve:
-    needs: 
+    needs:
       - plan
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment-for-approval }}
@@ -89,7 +89,7 @@ jobs:
           echo ${{ github.actor }}
   apply:
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - approve
     environment:  ${{ inputs.environment }}
     steps:
@@ -107,11 +107,11 @@ jobs:
         run: |
           pwd
           ls -la ../
-          cp -r scripts ../          
+          cp -r scripts ../
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          submodules: recursive           
+          submodules: recursive
       - name: Move /scripts to Working Directory
         run: |
           pwd
@@ -123,11 +123,9 @@ jobs:
           terraform_wrapper: false
       - name: Install python dependencies
         run: |
-          pip install -r scripts/requirements.txt          
+          pip install -r scripts/requirements.txt
       - name: Terraform Apply
         run: |
           terraform -v
           ls -la
           ./scripts/apply.sh
-
-          

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Common TRE github actions.
 
 ## Release History
 
-| Action                                            | Version | Summary                                     |
-| ------------------------------------------------- | ------- | ------------------------------------------- |
-| .github/actions/docker-build-and-deploy-to-ecr    | 0.0.1   | Created                                     |
-| .github/actions/docker-build-and-deploy-to-ecr    | 0.0.2   | Supports Docker build from AWS CodeArtifact |
-| .github/actions/get-next-version                  | 0.0.1   | Created                                     |
-| .github/workflows/tf-plan-approve-apply.yml       | 0.0.1   | Created                                     |
-| .github/workflows/docker-build-and-ecr-deploy.yml | 0.0.3   | Created                                     |
+| Action                                            | Tag   | Summary                                              |
+| ------------------------------------------------- | ----- | ---------------------------------------------------- |
+| .github/actions/docker-build-and-deploy-to-ecr    | 0.0.1 | Created                                              |
+| .github/actions/docker-build-and-deploy-to-ecr    | 0.0.2 | Supports Docker build from AWS CodeArtifact          |
+| .github/actions/get-next-version                  | 0.0.1 | Created                                              |
+| .github/workflows/docker-build-and-ecr-deploy.yml | 0.0.3 | Created                                              |
+| .github/workflows/tf-plan-approve-apply.yml       | 0.0.1 | Created                                              |
+| .github/workflows/tf-plan-approve-apply.yml       | 0.0.4 | Allow different manual approval step names (DTE-543) |


### PR DESCRIPTION
Accepts additional input parameter `environment-for-approval` that permits different GitHub environment names to be passed to the `terraform apply` manual checkpoint step (this replaces the previously hard-coded value `poc-manual-step`).

Assigned tag `0.0.4` to the change so caller can link to `nationalarchives/tre-github-actions/.github/workflows/tf-plan-approve-apply.yml@0.0.4` (as linking to `@main` could result in unexpected behaviour should the code change in the future).

Some formatting updates were also made.